### PR TITLE
Update flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,26 @@
   "nodes": {
     "cargo2nix": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "chir-rs",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "chir-rs",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "chir-rs",
+          "rust-overlay"
+        ]
       },
       "locked": {
-        "lastModified": 1638423893,
-        "narHash": "sha256-+NTV613zwK1G4UIKrj0gh1fYDvi85qO0wxy6h11azuY=",
+        "lastModified": 1652544855,
+        "narHash": "sha256-b7ToXDqgTXsAWPluHEiFmiqaJwIrdSyJgyAOBfty5xo=",
         "owner": "cargo2nix",
         "repo": "cargo2nix",
-        "rev": "ae8a5e699f57b446f9507b97a3c97a4e9fe06aa3",
+        "rev": "2cf825c2bd570e8561132f62cb9522258a4b4956",
         "type": "github"
       },
       "original": {
@@ -24,16 +34,16 @@
     "chir-rs": {
       "inputs": {
         "cargo2nix": "cargo2nix",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay_2"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1644510727,
-        "narHash": "sha256-wKOF20BZaCr7OaXBGFP18QzOuHKLb9+Yeeet+TQEvCU=",
+        "lastModified": 1652683717,
+        "narHash": "sha256-ukPzTzRSe1tqo4Np6ZUgM1rTSwNyytlBt122RRnLsmk=",
         "ref": "main",
-        "rev": "cc981ba2563bbad2b1f4df16d09229e2c4841157",
-        "revCount": 49,
+        "rev": "4743def15ea50d44f491a19f5564854452c59506",
+        "revCount": 52,
         "type": "git",
         "url": "https://git.chir.rs/darkkirb/chir.rs.git"
       },
@@ -45,8 +55,8 @@
     },
     "dns": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1644390195,
@@ -66,6 +76,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1648199409,
         "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
@@ -81,11 +107,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1652557277,
+        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
         "type": "github"
       },
       "original": {
@@ -95,21 +121,6 @@
       }
     },
     "flake-utils_2": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "locked": {
         "lastModified": 1614513358,
         "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
@@ -124,13 +135,13 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "locked": {
-        "lastModified": 1652557277,
-        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
+        "lastModified": 1652733177,
+        "narHash": "sha256-mRpdBbVk8tbYVgEE6oTBbFT1vkVdF7EzaP7bMQ26wWA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
+        "rev": "04b4d989fda8f14e6fcd1fee631eab9c54d15b97",
         "type": "github"
       },
       "original": {
@@ -268,7 +279,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -303,16 +314,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638109994,
-        "narHash": "sha256-OpA37PTiPMIqoRJbufbl5rOLII7HeeGcA0yl7FoyCIE=",
+        "lastModified": 1652681595,
+        "narHash": "sha256-xNC2jfvpXkzRA3SJfS75Qy/dXxKoJ1S4wQKlmFbzS78=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a284564b7f75ac4db73607db02076e8da9d42c9d",
+        "rev": "a24b5378d5648b6c0e4e13137bbfbbc143a207d3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-21.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -366,22 +376,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1644472683,
-        "narHash": "sha256-sP6iM4NksOYO6NFfTJ96cg+ClPnq6cdY30xKA1iYtyU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "7adc9c14ec74b27358a8df9b973087e351425a79",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1616989418,
         "narHash": "sha256-LcOn5wHR/1JwClfY/Ai/b+pSRY+d23QtIPQHwPAyHHI=",
         "owner": "NixOS",
@@ -395,7 +389,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1645296114,
         "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
@@ -410,13 +404,13 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
-        "lastModified": 1652643438,
-        "narHash": "sha256-yGkROUs9L1HN1hnBbxX2uOAhzFC5Y8YJJ5OombulwGs=",
+        "lastModified": 1652756703,
+        "narHash": "sha256-Vns5aN9+3WLRDAr6reSQzOkD+i5XwOyYPsWcdfWEceo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c260a40e0c1c819b6404d22618cbc5a51f8a733",
+        "rev": "8eb3f281dc1bd1a0599d29eca38e9bd9cfae3590",
         "type": "github"
       },
       "original": {
@@ -427,11 +421,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652639100,
-        "narHash": "sha256-IfBIwcvksquaV8c/jooskJwhQloOZpB+wlPuO9yMw8E=",
+        "lastModified": 1652760310,
+        "narHash": "sha256-61rI6TiJYAZMJ8g/+nN1F6E+fheTrmHNU7bd1t8uTT4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1944cd338ac341b00a288a8f8bb374b519ed4451",
+        "rev": "f8c21a8631907ef0b3ed88ac40b24e3c33fe850a",
         "type": "github"
       },
       "original": {
@@ -442,7 +436,7 @@
     },
     "polymc": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "libnbtplusplus": "libnbtplusplus",
         "nixpkgs": [
           "nixpkgs"
@@ -450,11 +444,11 @@
         "quazip": "quazip"
       },
       "locked": {
-        "lastModified": 1652472304,
-        "narHash": "sha256-V9/fc2h6F6qMxN0WiCJ/98fRzsc2yjvHUyvzB7o2eIo=",
+        "lastModified": 1652724419,
+        "narHash": "sha256-Ny/Mx1JspwhWsRHExcmW7Yiix6P8/V6dDJ1DbXRY82s=",
         "owner": "PolyMC",
         "repo": "PolyMC",
-        "rev": "123ed5bd2e12ad72b6df39ef747e31d64aae6dce",
+        "rev": "f66598db8aa756871dc21081e890158f889dc9e3",
         "type": "github"
       },
       "original": {
@@ -483,14 +477,14 @@
       "inputs": {
         "chir-rs": "chir-rs",
         "dns": "dns",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "home-manager": "home-manager",
         "hosts-list": "hosts-list",
         "hydra": "hydra",
         "miifox-net": "miifox-net",
         "nix": "nix",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-systemd-249": "nixpkgs-systemd-249",
         "nur": "nur",
         "polymc": "polymc",
@@ -501,33 +495,6 @@
       "inputs": {
         "flake-utils": [
           "chir-rs",
-          "cargo2nix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "chir-rs",
-          "cargo2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1638152159,
-        "narHash": "sha256-Q0UHsm36cCxk16I/bF1rHJHxjIflESKk2ej76P39j90=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d9a664513558376595e838b21348cdac0ba3115e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "flake-utils": [
-          "chir-rs",
           "flake-utils"
         ],
         "nixpkgs": [
@@ -536,11 +503,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644460328,
-        "narHash": "sha256-dUPKwjKtu3JY+uEWCr1gWnn3xOpfYABBg9I9/7KsiBk=",
+        "lastModified": 1652668492,
+        "narHash": "sha256-IkkheO8APgbJp7XO5DbYb2MynTJs6smE9EvDjrWA488=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c61a9719044869263d9a0488df170d8fec7d0ec3",
+        "rev": "ea19353ab585e3b35611368bad781aa3d10d973f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake.lock update

## Changes for nixos-8gb-fsn1-1:
```
perl5.34.0-Test-RequiresInternet: {'0.05'} -> removed
gdbm: {'1.20', '1.23'} -> {'1.23'}
more-itertools: {'8.12.0', '8.10.0'} -> {'8.12.0'}
glibc-locales: {'2.34-115', '2.33-78'} -> {'2.34-115'}
pip: {'22.0.4', '21.1.3'} -> {'22.0.4'}
tpm2-tss: {'3.2.0', '3.0.3'} -> {'3.2.0'}
lxml: {'4.8.0', '4.6.5'} -> {'4.8.0'}
patchelf: {'0.12', '0.13', '0.14.5'} -> {'0.12', '0.14.5'}
p11-kit: {'0.24.0', '0.24.1'} -> {'0.24.1'}
automake: {'1.16.3', '1.16.5', '1.15.1'} -> {'1.16.5', '1.15.1'}
markupsafe: {'2.0.1', '2.1.1'} -> {'2.1.1'}
nghttp2: {'1.47.0', '1.43.0'} -> {'1.47.0'}
perl5.34.0-HTML-Parser: {'3.75'} -> removed
perl5.34.0-IO-HTML: {'1.004'} -> removed
freezegun: {'1.2.1', '1.1.0'} -> {'1.2.1'}
curl: {'7.79.1', '7.83.0'} -> {'7.83.0'}
cbor2: {'5.4.2'} -> {'5.4.2.post1'}
libgcrypt: {'1.9.4', '1.10.1'} -> {'1.10.1'}
python3-minimal: {'3.9.12', '3.8.8', '3.9.6'} -> {'3.9.12', '3.8.8'}
libseccomp: {'2.5.3', '2.5.2'} -> {'2.5.3'}
iproute2: {'5.17.0', '5.14.0'} -> {'5.17.0'}
binutils-wrapper: {'2.38', '2.35.2', '2.35.1'} -> {'2.38', '2.35.1'}
python3: {'3.9.12', '3.9.6'} -> {'3.9.12'}
perl5.34.0-libwww-perl: {'6.49'} -> removed
gcc-wrapper: {'10.2.0', '11.3.0', '10.3.0'} -> {'10.2.0', '11.3.0'}
perl5.34.0-LWP-MediaTypes: {'6.04'} -> removed
readline: {'8.1p2', '8.1p0', '6.3p08'} -> {'8.1p2', '6.3p08'}
unbound: {'1.13.2', '1.14.0'} -> {'1.14.0'}
binutils: {'2.38', '2.35.2', '2.35.1'} -> {'2.38', '2.35.1'}
shadow: {'4.8.1', '4.11.1'} -> {'4.11.1'}
help2man: {'1.49.1', '1.48.5'} -> {'1.49.1'}
expat: {'2.4.8', '2.4.3'} -> {'2.4.8'}
libcap-ng: {'0.8.2', '0.8.3'} -> {'0.8.3'}
gnutls: {'3.7.2', '3.7.3'} -> {'3.7.3'}
libcbor: {'0.8.0', '0.9.0'} -> {'0.9.0'}
hypothesis: {'6.40.0', '6.24.5'} -> {'6.40.0'}
nix: {'2.8.0'} -> {'2.8.1'}
packaging: {'21.3', '20.9'} -> {'21.3'}
perl5.34.0-HTML-Tagset: {'3.20'} -> removed
libksba: {'1.6.0', '1.5.1'} -> {'1.6.0'}
perl5.34.0-WWW-RobotRules: {'6.02'} -> removed
c-ares: {'1.18.1', '1.17.2'} -> {'1.18.1'}
libxslt: {'1.1.34', '1.1.35'} -> {'1.1.35'}
perl5.34.0-gettext: {'1.07'} -> removed
libcap: {'2.63', '2.49'} -> {'2.63'}
bootstrap-stage4-gcc-wrapper: {'11.3.0', '10.2.0', '10.3.0'} -> {'11.3.0', '10.2.0'}
systemd: {'234', '249.7', '250.4'} -> {'234', '250.4'}
tomlkit: {'0.10.1', '0.7.2'} -> {'0.10.1'}
cmake: {'3.22.3', '3.21.2'} -> {'3.22.3'}
docutils: {'0.17.1', '0.18.1'} -> {'0.18.1'}
setuptools: {'57.2.0', '61.2.0'} -> {'61.2.0'}
gcc: {'10.2.0', '11.3.0', '10.3.0'} -> {'10.2.0', '11.3.0'}
perl5.34.0-Net-HTTP: {'6.19'} -> removed
zstd: {'1.5.0', '1.5.2'} -> {'1.5.2'}
flit-core: {'3.2.0', '3.7.1'} -> {'3.7.1'}
tzdata: {'2021c', '2022.1', '2022a'} -> {'2022.1', '2022a'}
sqlite: {'3.36.0', '3.38.3'} -> {'3.38.3'}
util-linux: {'2.37.4', '2.37.3'} -> {'2.37.4'}
perl5.34.0-CPAN-Meta-Check: {'0.014'} -> removed
pytz: {'2022.1', '2021.3'} -> {'2022.1'}
libarchive: {'3.6.1', '3.5.2'} -> {'3.6.1'}
pytest: {'7.1.1', '6.2.5'} -> {'7.1.1'}
re2c: {'3.0', '2.2'} -> {'3.0'}
perl5.34.0-HTTP-Negotiate: {'6.01'} -> removed
perl5.34.0-Encode-Locale: {'1.05'} -> removed
gnupg: {'2.2.27', '2.3.4'} -> {'2.3.4'}
libapparmor: {'3.0.3', '3.0.4'} -> {'3.0.4'}
libfido2: {'1.8.0', '1.10.0'} -> {'1.10.0'}
findutils: {'4.8.0', '4.9.0', '4.7.0'} -> {'4.9.0', '4.7.0'}
glib: {'2.70.1', '2.72.1'} -> {'2.72.1'}
libselinux: {'3.0', '3.3'} -> {'3.3'}
cmake-boot: {'3.22.3', '3.21.2'} -> {'3.22.3'}
libmnl: {'1.0.4', '1.0.5'} -> {'1.0.5'}
linux-headers: {'5.14', '5.11', '5.17'} -> {'5.11', '5.17'}
meson: {'0.61.2', '0.57.1'} -> {'0.61.2'}
Jinja2: {'3.1.1', '3.0.2'} -> {'3.1.1'}
lvm2: {'2.03.12', '2.03.15'} -> {'2.03.15'}
doxygen: {'1.8.20', '1.9.3'} -> {'1.9.3'}
tomli: {'2.0.1', '1.2.1'} -> {'2.0.1'}
wcwidth: {'0.2.5', '0.0.2'} -> {'0.0.2'}
libxml2: {'2.9.12', '2.9.14'} -> {'2.9.14'}
libsepol: {'3.0', '3.3'} -> {'3.3'}
Pygments: {'2.10.0', '2.11.2'} -> {'2.11.2'}
rust-std: {'1.58.1'} -> {'1.60.0'}
py: {'1.10.0', '1.11.0'} -> {'1.11.0'}
pcre2: {'10.39', '10.37'} -> {'10.39'}
gzip: {'1.11', '1.10', '1.12'} -> {'1.10', '1.12'}
rustc: {'1.60.0', '1.58.1'} -> {'1.60.0'}
glibc: {'2.34-115', '2.33-78'} -> {'2.34-115'}
Cython: {'0.29.28', '0.29.24'} -> {'0.29.28'}
boost-build: {'boost-1.69.0', 'boost-1.77.0'} -> {'boost-1.77.0'}
setuptools-scm: {'6.3.2', '6.4.2'} -> {'6.4.2'}
boost: {'1.69.0', '1.77.0'} -> {'1.77.0'}
rust-src: {'1.58.1'} -> {'1.60.0'}
perl5.34.0-Test-Deep: {'1.130'} -> removed
libuv: {'1.42.0', '1.44.1'} -> {'1.44.1'}
perl5.34.0-URI: {'5.05'} -> removed
openssl: {'1.1.1m', '1.1.1o'} -> {'1.1.1o'}
libnftnl: {'1.2.0', '1.2.1'} -> {'1.2.1'}
attrs: {'21.2.0', '21.4.0'} -> {'21.4.0'}
cargo: {'1.60.0', '1.58.1'} -> {'1.60.0'}
perl5.34.0-HTTP-Cookies: {'6.09'} -> removed
libnetfilter_conntrack: {'1.0.8', '1.0.9'} -> {'1.0.9'}
perl5.34.0-HTTP-Daemon: {'6.01'} -> removed
perl5.34.0-Capture-Tiny: {'0.48'} -> removed
wheel: {'0.36.2', '0.37.1'} -> {'0.37.1'}
perl5.34.0-HTTP-Message: {'6.26'} -> removed
perl5.34.0-Test-Needs: {'0.002006'} -> removed
coverage: {'6.3.2', '5.5'} -> {'6.3.2'}
rust-minimal: {'1.58.1'} -> {'1.60.0'}
perl5.34.0-File-Listing: {'6.14'} -> removed
PyYAML: {'5.4.1.1'} -> removed
nix-direnv: {'2.0.1'} -> {'2.1.0'}
perl5.34.0-HTTP-Date: {'6.05'} -> removed
systemd-minimal: {'249.7', '250.4'} -> {'250.4'}
linux-pam: {'1.5.1', '1.5.2'} -> {'1.5.2'}
atomicwrites: {'1.4.0'} -> removed
perl5.34.0-Test-Fatal: {'0.016'} -> removed
perl5.34.0-XML-Parser: {'2.46'} -> removed
perl5.34.0-Try-Tiny: {'0.30'} -> removed
perl5.34.0-TimeDate: {'2.33'} -> removed
chir-rs-login: added -> {'/nix/store/d8ands6fvyzjzbnrqbxxzb11g2rnp9p2-chir-rs-login-app.drv'}
```
## Changes for nutty-noon:
```
gtk4: {'4.6.3'} -> {'4.6.4'}
nix: {'2.8.0'} -> {'2.8.1'}
firefox: {'100.0'} -> {'100.0.1'}
polymc: {'20220513'} -> {'20220516'}
thunderbird: {'91.8.1'} -> {'91.9.0'}
quazip: {'1.2'} -> removed
nix-direnv: {'2.0.1'} -> {'2.1.0'}
keepassxc: {'2.6.6'} -> {'2.7.1'}
botan: added -> {'2.18.1'}
```
## Changes for thinkrac:
```
gtk4: {'4.6.3'} -> {'4.6.4'}
nix: {'2.8.0'} -> {'2.8.1'}
firefox: {'100.0'} -> {'100.0.1'}
polymc: {'20220513'} -> {'20220516'}
thunderbird: {'91.8.1'} -> {'91.9.0'}
quazip: {'1.2'} -> removed
microcode-intel: {'20220419'} -> {'20220510'}
nix-direnv: {'2.0.1'} -> {'2.1.0'}
keepassxc: {'2.6.6'} -> {'2.7.1'}
botan: added -> {'2.18.1'}
```
## Changes for installer:
```
nix: {'2.8.0'} -> {'2.8.1'}
```
## Changes for nas:
```
nix: {'2.8.0'} -> {'2.8.1'}
xmlschema: {'1.10.0'} -> {'1.11.0'}
nix-direnv: {'2.0.1'} -> {'2.1.0'}
yajl: added -> {'2.1.0'}
```