### PR TITLE
Caddy b2 writes

### DIFF
--- a/config/services/reverse-proxy.nix
+++ b/config/services/reverse-proxy.nix
@@ -66,6 +66,9 @@ in {
       useACMEHost = "chir.rs";
       extraConfig = ''
         import baseConfig
+        
+        uri strip_prefix /cache
+        
         @getOnly {
           method GET
         }


### PR DESCRIPTION
the nix s3 client accesses the bucket over a subdirectory and not a subdomain, we need to remove the suffix to make sure that it works