### PR TITLE
 Remove a.rathersafe.space from the media removal 

### DIFF
--- a/config/services/akkoma/default.nix
+++ b/config/services/akkoma/default.nix
@@ -111,9 +111,6 @@
           "beefyboys.win" = "freeze peach; hosts neonazis";
           "bae.st" = "freeze peach";
         };
-        media_removal = processMap {
-          "a.rathersafe.space" = "posting borderline illegal imagery as the fediblock account";
-        };
       };
       ":mrf" = {
         policies = map (v: mkRaw ("Pleroma.Web.ActivityPub.MRF." + v)) ["SimplePolicy" "EnsureRePrepended" "MediaProxyWarmingPolicy" "ForceBotUnlistedPolicy" "AntiFollowbotPolicy" "ObjectAgePolicy" "TagPolicy" "RequireImageDescription"];


### PR DESCRIPTION
reasons:

- no longer exists