### PR TITLE
Update akkoma moderation

### DIFF
--- a/config/services/akkoma/default.nix
+++ b/config/services/akkoma/default.nix
@@ -98,7 +98,7 @@
         processMap = m: map (k: mkTuple [k m.${k}]) (builtins.attrNames m);
       in {
         reject = processMap {
-          "qoto.org" = "Freeze Peach";
+          "qoto.org" = "Freeze Peach; Admin harasses other server admins; sends unsolicited emails";
           "poa.st" = "Hosting neonazis";
           "kiwifarms.cc" = "Targeted Harassment";
           "pmth.us" = "Harassment";
@@ -110,6 +110,11 @@
           "xhais.love" = "Zoophile instance";
           "beefyboys.win" = "freeze peach; hosts neonazis";
           "bae.st" = "freeze peach";
+        };
+        federated_timeline_removal = processMap {
+          "mastodon.social" = "Too large to be moderated well";
+          "mastodon.online" = "Too large to be moderated well";
+          "tumblr.com" = "Too large to be moderated well, corporate instance";
         };
       };
       ":mrf" = {


### PR DESCRIPTION
qoto.org
--------

Ban reason clarified to refer to include harassment toward
@david@tech.lgbt and other fediverse admins. Also that email that the
admin sent to every instance admin whose email they could find.

mastodon.social and mastodon.online
-----------------------------------

Removed from the whole known network because the two instances are too
large to be able to be effectively moderated.

tumblr.com
----------

Removed from the whole known network for the same reason as m.o and m.s,
and also because it’s a corporate instance
