### PR TITLE
Block vivaldi.net

### DIFF
--- a/config/services/akkoma/default.nix
+++ b/config/services/akkoma/default.nix
@@ -110,6 +110,7 @@
           "xhais.love" = "Zoophile instance";
           "beefyboys.win" = "freeze peach; hosts neonazis";
           "bae.st" = "freeze peach";
+          "vivaldi.net" = "Corporate instance; Registers nonconsensual accounts for Vivaldi Sync users";
         };
         federated_timeline_removal = processMap {
           "mastodon.social" = "Too large to be moderated well";


### PR DESCRIPTION
Reasons:

- Corporate Instance
- Registers nonconsensual accounts for its vivaldi sync users
  https://meow.social/@Tiwy57/109432020210507907
