### PR TITLE
Block feral.cafe

### DIFF
--- a/config/services/akkoma/default.nix
+++ b/config/services/akkoma/default.nix
@@ -130,6 +130,7 @@
           "bae.st" = "freeze peach";
           "vivaldi.net" = "Corporate instance; Registers nonconsensual accounts for Vivaldi Sync users";
           "moth.zone" = "racism/antiblackness; owner self-admitted pedophile";
+          "feral.cafe" = "Zoophilia";
         };
         federated_timeline_removal = processMap {
           "mastodon.social" = "Too large to be moderated well";


### PR DESCRIPTION
Reason:

their Rule 14: Zoosexuality is protected as a sexual orientation on this instance

most of their active users (scrolling through local timeline) are open zoophiles
