### PR TITLE
Workaround terrible user agent sniffing from embed bug workaround services

### DIFF
--- a/config/services/matrix-media-repo.nix
+++ b/config/services/matrix-media-repo.nix
@@ -65,7 +65,8 @@
         "fe80::/64"
         "fc00::/7"
       ];
-      userAgent = "TelegramBot (like TwitterBot)"; # to make it work with fxtwitter/vxtwitter
+      # user agent header was a mistake
+      userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0, matrix-media-repo (like twitterbot; like telegrambot; like discordbot; like facebook; like whatsapp; like firefox/92; like vkshare) +https://github.com/DarkKirb/nixos-config/pull/264"; 
     };
     downloads = {
       expireAfterDays = 7;


### PR DESCRIPTION
You may have been linked here by a link in your log files, in which case I implore you to stop sniffing user agents to figure out what content to serve. It’s why user agents are so complex and everything pretends to be something else. I do not want to have to petition you individually to permit my particular embed crawler to see your embeds. serve them unconditionally.